### PR TITLE
Fix panic: When() for func that fixed arguments, at least one, and variadic arguments

### DIFF
--- a/cond.go
+++ b/cond.go
@@ -6,6 +6,7 @@ type anyMatcher int
 
 func (anyMatcher) canAccept(arg *typeval) bool { return true }
 func (anyMatcher) equal(o condExpr) bool       { return o == Any }
+func (anyMatcher) String() string              { return "<any>" }
 
 var _ condExpr = (anyMatcher)(0)
 

--- a/func.go
+++ b/func.go
@@ -201,7 +201,7 @@ func checkMatcherPattern(values []any, types []reflect.Type, isVariadic bool) ([
 
 func flattenVariadicType(types []reflect.Type, n int) []reflect.Type {
 	if len(types) > n {
-		return types
+		return types[:len(types)-1]
 	}
 	a := make([]reflect.Type, n)
 	last := types[len(types)-1]

--- a/func_test.go
+++ b/func_test.go
@@ -1,6 +1,7 @@
 package mofu
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"testing"
@@ -301,10 +302,19 @@ func TestMock_When(t *testing.T) {
 		m.When(30)
 	})
 
-	t.Run("variadic arguments", func(t *testing.T) {
+	t.Run("variadic arguments only", func(t *testing.T) {
 		m := MockOf(fmt.Sprint)
 		m.When(1, 2).ReturnOnce("1 2")
 		fn, _ := m.Make()
 		gt.Equal(t, fn(1, 2), "1 2")
+	})
+
+	t.Run("variadic and fixed arguments", func(t *testing.T) {
+		type getObjectFunc func(ctx context.Context, path string, opts ...func())
+		m := MockFor[getObjectFunc]()
+		m.When(Any, "file")
+		fn, r := m.Make()
+		fn(context.Background(), "file")
+		gt.Number(t, r.Count()).Equal(1)
 	})
 }


### PR DESCRIPTION
```console
$ go test
--- FAIL: TestMock_When (0.00s)
    --- FAIL: TestMock_When/variadic2 (0.00s)
panic: number of args/results must match to the function signature: [context.Context string []func()] vs [<any> file] [recovered]
        panic: number of args/results must match to the function signature: [context.Context string []func()] vs [<any> file]

goroutine 46 [running]:
testing.tRunner.func1.2({0x6b1340, 0xc000027080})
        /usr/lib/go/src/testing/testing.go:1734 +0x21c
testing.tRunner.func1()
        /usr/lib/go/src/testing/testing.go:1737 +0x35e
panic({0x6b1340?, 0xc000027080?})
        /usr/lib/go/src/runtime/panic.go:792 +0x132
github.com/lufia/mofu.(*Mock[...]).When(0x779aa0, {0xc000090a80, 0x2, 0x2})
        /home/lufia/src/mofu/func.go:316 +0xf7
github.com/lufia/mofu.TestMock_When.func8(0xc0001c2380)
        /home/lufia/src/mofu/func_test.go:315 +0x7d
testing.tRunner(0xc0001c2380, 0x71e4d0)
        /usr/lib/go/src/testing/testing.go:1792 +0xf4
created by testing.(*T).Run in goroutine 38
        /usr/lib/go/src/testing/testing.go:1851 +0x413
exit status 2
FAIL    github.com/lufia/mofu   0.005s
```